### PR TITLE
add package.json for `cordova plugin add <repo-url>` compatibilty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "com.abdsoft.Hash",
+  "version": "0.1.0",
+  "description": "Cordova Hash Plugin",
+  "cordova": {
+    "id": "com.abdsoft.Hash",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Abdsoft/phonegap-hash.git"
+  },
+  "keywords": [
+    "cordova",
+    "Hash",
+    "ecosystem:cordova",
+    "cordova-android",
+    "cordova-ios"
+  ],
+  "author": "Abdsoft",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Abdsoft/phonegap-hash/issues"
+  },
+  "homepage": "https://github.com/Abdsoft/phonegap-hash#readme"
+}


### PR DESCRIPTION
Fixes:
```
Error: Failed to fetch plugin https://github.com/Abdsoft/phonegap-hash via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
Check your connection and plugin name/version/URL.
Error: npm: Command failed with exit code 1 Error output:
npm ERR! code ENOPACKAGEJSON
npm ERR! package.json Non-registry package missing package.json: git+https://github.com/Abdsoft/phonegap-hash.git.
npm ERR! package.json npm can't find a package.json file in your current directory.
```